### PR TITLE
Add '+' as valid character

### DIFF
--- a/src/examples/SVM/svm_example.cu
+++ b/src/examples/SVM/svm_example.cu
@@ -77,7 +77,7 @@ namespace GPUMLib {
 	bool validCharacter(char &c) {
 		if (c >= '0' && c <= '9')
 			return true;
-		if (c == ',' || c == '.' || c == ' ' || c == '\r' || c == '\n' || c == '-' || c == 'e' || c == 'E')
+		if (c == ',' || c == '.' || c == ' ' || c == '\r' || c == '\n' || c == '-' || c == '+' || c == 'e' || c == 'E')
 			return true;
 		return 0;
 	}


### PR DESCRIPTION
Add + as a valid character since often the scientific notation contains a + in the exponent (e.g., 1.234e+2).